### PR TITLE
Updated the `mockTestFolder` method top keep any symlinks when copying the seed to the temp folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ git commit
 require('organic-stem-tester')
 
 var stem = new StemSkeleton('/home/my-stem-seed')
-stem.mockTestFolder(function (err) {}) // mocks a test folder at /tmp
+stem.mockTestFolder(function (err) {}) // mocks a test folder at /tmp, while retaining linked node modules
 stem.removeMockedFolder(function (err) {}) // removes the test folder
 
 // bellow are executed towards the test folder as cwd

--- a/lib/StemSkeleton.js
+++ b/lib/StemSkeleton.js
@@ -14,7 +14,7 @@ module.exports = class StemSkeleton {
       this.targetDir = dirPath
       console.info('INFO: using stem seed folder', this.mockStemSeedPath, ' stem mock', this.targetDir)
       this.shellExec([
-        'cp -rL ' + this.mockStemSeedPath + '/* ' + this.targetDir
+        'cp -ra ' + this.mockStemSeedPath + '/* ' + this.targetDir
       ].join(' && '), {}, (err) => {
         if (err) return done(err)
         console.info('INFO: using stem mock folder', this.targetDir)


### PR DESCRIPTION
This PR resolves Issue #1